### PR TITLE
add seurat to remotes & simplify runtime

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -36,7 +36,8 @@ Imports:
     dbscan,
     tibble
 Remotes:
-    kevinsblake/NatParksPalettes
+    kevinsblake/NatParksPalettes, 
+    satijalab/seurat
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.3.3
 Suggests: 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: tcrClustR
 Title: Define TCR "Families" via similarity metrics
-Version: 0.0.0.9000
+Version: 0.0.0.9002
 Authors@R: 
     person("GW", "McElfresh", ,"mcelfreg@ohsu.edu", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0002-1948-7571"))

--- a/Dockerfile
+++ b/Dockerfile
@@ -153,9 +153,6 @@ WORKDIR /tcrClustR
 # upgrade = 'never' is specified because the dependencies install/upgrading is already handled in the deps stage
 RUN cd /tcrClustR && \
     R CMD build . && \
-    Rscript -e "BiocManager::install(ask = F, upgrade = 'never');" && \
-    Rscript -e "install.packages('devtools', dependencies=TRUE, lib='/usr/local/lib/R/site-library'); \
-    devtools::install_deps(pkg = '.', dependencies = TRUE, upgrade = 'never');" && \
     R CMD INSTALL --build *.tar.gz && \
     rm -Rf /tmp/downloaded_packages/ /tmp/*.rds
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -67,6 +67,9 @@ RUN if [ "$SKIP_BASE_DEPS" = "false" ]; then \
         libcairo2-dev \
         libgpg-error-dev \
         libgmp-dev \
+        libprotobuf-dev \
+        protobuf-compiler \
+        libnode-dev \
         ca-certificates \
         && rm -rf /var/lib/apt/lists/*; \
     else \


### PR DESCRIPTION
Fix omission from #53 to pull the dev branch from seurat. 

Also, the runtime image doesn't need to check dependencies, since those are handled by the dependency image and synchronized by the hash. I am fairly certain that checking the dependencies at this stage will only check CRAN/Bioconductor and show that a dev branch of Seurat can't be satisfied. 